### PR TITLE
feat: Implemented display of landing point prediction

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,6 +213,10 @@ function drawBlock(x, y, colorIndex) {
     context.fillStyle = TETROMINO_COLORS[colorIndex];
     //塗りつぶしの四角形（Rect)を描画します
     context.fillRect(pointX, pointY, BLOCK_SIZE, BLOCK_SIZE);
+  } else {
+    // 0が渡されたら着地点の予想位置に灰色ブロックを描画
+    context.fillStyle = "rgba(192,192,192,0.7)";
+    context.fillRect(pointX, pointY, BLOCK_SIZE, BLOCK_SIZE);
   }
 
   //ブロックの輪郭
@@ -245,6 +249,7 @@ function drawField() {
 function drawTetromino() {
   //着地点の高さ
   let plus = 0;
+  while (checkMove(0, plus + 1)) plus++;
 
   //テトロミノの配列をチェックし、形に合わせてブロックを描画します
   for (let y = 0; y < TETROMINO_SIZE; y++) {
@@ -291,15 +296,12 @@ document.onkeydown = function (e) {
   switch (e.key) {
     case "ArrowLeft": // 左
       if (checkMove(-1, 0)) tetromino_x--;
-      //tetromino_x--;
       break;
     case "ArrowRight": // 右
       if (checkMove(1, 0)) tetromino_x++;
-      //tetromino_x++;
       break;
     case "ArrowDown": // 下
       if (checkMove(0, 1)) tetromino_y++;
-      //tetromino_y++;
       break;
     case "ArrowUp": // 上
       // テトロミノを移動できなくなるまで落とす

--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ function onClearInterval() {
 // ストップボタン押したときの処理
 document.getElementById("stop-button").onclick = () => {
   // ゲーム実行中の場合のみ動きます
-  if (gameStartFlg) {
+  if (gameStartFlg && !gameOverFlg) {
     if (stopButtonFlg) {
       // STOPボタンの時
       onStopButton();
@@ -425,7 +425,7 @@ function onStopButton() {
     onClearInterval();
 
     // PAUSEと画面に表示する
-    drawCaption("PAUSE", 60, "yellow");
+    if (!gameOverFlg) drawCaption("PAUSE", 60, "yellow");
 
     // STOPボタンの表示をRESTARTに変更
     document.getElementById("action").innerHTML = "RESTART";


### PR DESCRIPTION
### 関連している Issue / 目的
Issueなし
着地点の予想を表示

### 達成条件
着地点の予想場所に灰色のブロックが表示されているか

### 実装の概要 / この PR の対応範囲
着地点予想場所に灰色のブロックを表示するようにしました。
少し透明度を下げた結果、副産物として、落としたブロックが固定されているかされていないかを判別することができるようになってます。

### 重点的にレビューして欲しいところ
灰色のブロックが表示されるか

### 不安に思っていること
枠線が黒いままなのが気になるので余裕あれば修正するかも？

### その他情報（スクリーンショット等）

### 次回担当したい作業
引き続き、フロント周りでできそうなことを探しながらやってみます。
なにをやるかは作業前にDiscordでお知らせすると思います。
